### PR TITLE
Zone detection fix

### DIFF
--- a/gamemode/zones/sh_zone.lua
+++ b/gamemode/zones/sh_zone.lua
@@ -73,30 +73,12 @@ function CuboidOverlap( min1, max1, min2, max2 )
 	local min1, max1 = VectorMinMax( min1, max1 )
 	local min2, max2 = VectorMinMax( min2, max2 )
 
-	local pass = 0
-
-	if VectorInCuboid( min1, min2, max2 ) then
-		return true
-	elseif VectorInCuboid( max1, min2, max2 ) then
-		return true
-	elseif VectorInCuboid( min2, min1, max1 ) then
-		return true
-	elseif VectorInCuboid( max2, min1, max1 ) then
-		return true
+	if (
+		((min1.x <= min2.x and min2.x <= max1.x) or (min2.x <= min1.x and min1.x <= max2.x)) and
+		((min1.y <= min2.y and min2.y <= max1.y) or (min2.y <= min1.y and min1.y <= max2.y)) and
+		((min1.z <= min2.z and min2.z <= max1.z) or (min2.z <= min1.z and min1.z <= max2.z)) 
+		) then
+		return true 
+		else return false
 	end
-
-	if (min1.x > min2.x) ~= (max1.x > max2.x) then
-		pass = pass + 1
-	end
-
-	if (min1.y > min2.y) ~= (max1.y > max2.y) then
-		pass = pass + 1
-	end
-
-	if (min1.z > min2.z) ~= (max1.z > max2.z) then
-		pass = pass + 1
-	end
-
-	if pass >= 3 then return true else return false end
-
 end

--- a/gamemode/zones/sv_zone.lua
+++ b/gamemode/zones/sv_zone.lua
@@ -96,8 +96,11 @@ function ZONE:Tick() -- cycle through zones and check for players
 	if skipcount == skip then
 		for name, z in pairs( self.zones ) do
 			if z.type then
-				for k, ply in ipairs(player.GetAllPlaying()) do
-					if ply:GetPos():Distance( (z.pos1 + z.pos2)/2 ) < z.pos1:Distance(z.pos2) * 0.6 then
+				local border = Vector(20,20,20)
+				local posmin, posmax = VectorMinMax(z.pos1, z.pos2)
+				for k, ply in ipairs(ents.FindInBox(posmin - border,posmax + border)) do
+					if ply:IsPlayer() == true then
+						print("test")
 						-- create a bunch of variables on the player
 						ply.InZones = ply.InZones or {}
 


### PR DESCRIPTION
The gamemode didn't detect players entered a zone from X+ or Y+ until ply:GetPos() had entered the zone. This was caused by what I assuemed was bad logic on CuboidOverlap() where these cases didn't return the function as true.
The propper hooks would only be called when VectorInCuboid() returned true for the vector ply:GetPos()